### PR TITLE
Search single-page app - comitting solution

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -38,5 +38,6 @@ class NewsPostSerializer(serializers.HyperlinkedModelSerializer):
             'publish_date',
             'source',
             'divesite',
-            'topics',
+            'topics', 
+            'topic_names' # added this property to make things a little easier in the frontend, since this whole thing is a bit quick and dirty to begin with.
         ]

--- a/apps/news/models.py
+++ b/apps/news/models.py
@@ -43,6 +43,13 @@ class NewsPost(models.Model):
     def source_divesite(self):
         return self.divesite.display_name
 
+    # This will make front end implementation a bit easier since we're not using any big front-end frameworks to handle the data model,
+    # and we just need the names so we can render the tags. If I had more time I'd want to have the topic model fully represented in the
+    # front-end, so this wouldn't be necessary since JS could just query for the topic objects and not have to get them from the news endpoint.
+    @property
+    def topic_names(self):
+        return [topic.display_name for topic in self.topics.all()]
+
     def tags(self):
         return [
             'HR', 'Diversity & Inclusion', 'Culture'

--- a/static/js/live_search.js
+++ b/static/js/live_search.js
@@ -1,0 +1,140 @@
+// This is a very quick and dirty 2010's style jQuery implementation of a dynamic search results app. I'd prefer to use a more modern front-end
+// framework in an actual production app, but this is quick enough for me to write without having to bring in too much external code (besides jQ).
+
+$(document).ready(function(){
+	var $topics = $('#topics');
+	var $searchinput = $('#id_text_search');
+	var $search_results = $('#search_results');
+	var $search_results_feed = $('#search_results_feed');
+	var $archived_posts = $('#news_archive');
+	var $search_term = $('#search_term');
+	var $clear = $('#clear');
+
+	var search_text = "";
+
+	// from: http://davidwalsh.name/javascript-debounce-function
+	// This is necessary to keep the text search from initiating 
+	// a new AJAX request on every keypress when typing quickly
+	function debounce(func, wait, immediate) {
+	    var timeout;
+	    return function() {
+	        var context = this, args = arguments;
+	        var later = function() {
+	            timeout = null;
+	            if (!immediate) func.apply(context, args);
+	        };
+	        var callNow = immediate && !timeout;
+	        clearTimeout(timeout);
+	        timeout = setTimeout(later, wait);
+	        if (callNow) func.apply(context, args);
+	    };
+	};
+
+	// Compose the backend query, fire it off, and then render the new data into the page when it arrives
+	function get_results() {
+		var $topic_list = $('#topic_list');
+		var query_string = "";
+
+		// Clear the topic list of any existing topics
+		$topic_list.html("");
+
+		// Use the selected topics to formulate the query string
+		$topics.find("option:selected").each(function() {
+			var value = $(this).val();
+			query_string += "topics_" + value + "=" + value + "&";
+			$topic_list.append(render_topic_tag($(this).html())); // render this topic tag in the list of topics!
+		});
+
+		if (search_text) {
+			// good to make sure our inputs will work as GET params in the query string!
+			query_string +=	"text_search=" + encodeURIComponent(search_text); 
+			$search_term.html(search_text);
+		}
+
+		$.ajax({
+			url: "/api/v1/news/",
+			data: query_string
+		}).done(function(data){
+			$search_results_feed.html(""); // Clear the search results of any existing posts
+
+			$.each(data, function(index, value) {
+				$search_results_feed.append(render_post(value, index)); // render each post snippet
+			})
+		})
+	}
+
+	// Do we want to show Django's news archive output or the js-powered search results? If the latter, kick off an update of search results.
+	// Toggles whether the dynamic results or the django-rendered results <span>'s are showing/hidden
+	function update_page() {
+		if ($topics.find("option:selected").length || search_text != "") {
+			get_results();
+			$search_results.show();
+			$archived_posts.hide();
+		} else {
+			$search_results.hide();
+			$archived_posts.show();
+		}
+	}
+
+	// Given a topic name, output a jQuery object encapsulating a topic tag.
+	function render_topic_tag(topic) {
+		var $tag = $("<div>");
+
+		$tag.attr('class', 'label label--tag');
+		$tag.html(topic);
+
+		return $tag;
+	}
+
+	// Given a post and post index, output a jQuery object encapsulating a news post
+	function render_post(post, i) {
+		var $post = $("<li>");
+
+		$post.attr('data-newspost-id', post.id);
+		$post.attr('data-feed-placement', i);
+
+		var $labelSpan = $('<span class="label label--soft">');
+		$labelSpan.html(post.publish_date);
+
+		$post.append($labelSpan);
+
+		$.each(post.topic_names, function(index, value) {
+			$post.append(render_topic_tag(value));
+		});
+
+		var $feedLink = $("<div class='feed-link'>");
+		$feedLink.append($("<a>").attr('href', post.source).html(post.title));
+
+		$post.append($feedLink);
+
+		var $feedTeaser = $("<div class='feed-teaser'>");
+		$feedTeaser.attr('data-story_id', post.id);
+		$feedTeaser.html(post.teaser + " ...");
+
+		$post.append($feedTeaser);
+
+		return $post;
+	}
+
+	// Trigger an update when topics are changed
+	$topics.change(function() {
+		update_page();
+	}).change();
+
+	// Trigger an update when search text changes; debounced for better UX
+	$searchinput.keyup(debounce(function() {
+		search_text = $(this).val();
+		update_page();
+	}, 500)).change();
+
+	// Resets all filtering/search
+	$clear.click(function(){
+		$searchinput.val("");
+		search_text = "";
+		$topics.val([]);
+		update_page();
+	});
+
+	update_page();
+
+});

--- a/templates/news/archive.html
+++ b/templates/news/archive.html
@@ -3,6 +3,7 @@
 
 {% block extra_style %}
 	<link href="{% static 'css/news.css' %}" rel="stylesheet">
+	<script src="{% static 'js/live_search.js' %}"></script>
 {% endblock %}
 
 {% block page_content %}
@@ -12,13 +13,12 @@
 				<label for="topics">Filter by topic:</label>
 			</div>
 			<div class="col">
-				<ul class="form form-multiselect">
-				{% for topic in topics %}
-					<li><input type="checkbox" name="topics_{{topic.pk}}" id="id_topics_{{topic.pk}}" value="{{topic.id}}" 
-						{% if topic in selected_topics %}checked=checked{% endif %}
-						> {{topic.display_name}}</li>
-				{% endfor %}
-				</ul>
+				<!-- Changing this to a select makes it just a bit easier to work with in jQuery. -->
+				<select id="topics" name="topics" multiple="multiple" class="form form-multiselect">
+				  {% for topic in topics %}
+				  	<option value="{{topic.id}}">{{topic.display_name}}</option>
+				  {% endfor %}
+				</select>
 			</div>
 			<div class="col-sm-1 col-form-label">
 				<label for="text_search">Text:</label>
@@ -27,37 +27,44 @@
 				<input type="text" id="id_text_search" name="text_search" class="form-control" {% if text_search %}value="{{text_search}}" {% endif %}/>
 			</div>
 			<div class="col">
-				<input type="submit" id="id_submit" name="submit" class="btn btn-dark" value="search" />
+				<!-- Submit is no longer useful, but 'Clear' is! -->
+				<input type="button" id="clear" name="clear" class="btn btn-dark" value="Clear" />
 			</div>
 		</div>
 	</form>
-	{% if searched %}
-		<span class="search">
-			<div class="row" id="search-result-header">
-				<h2>Search Results</h2>
-			</div>
-			<div class="row search-description">
-				{% if text_search_value %}
+	<span class="search" id="search_results">
+		<div class="row" id="search-result-header">
+			<h2>Search Results</h2>
+		</div>
+		<div class="row search-description">
+
+			<span id="search_text_display">
 				<div class="col">
-					<b>Search term:</b> "{{text_search_value}}"
+					<b>Search term:</b> <span id="search_term"></span> <!-- JS will populate this with the current search term when applicable -->
 				</div>
-				{% endif %}
-				{% if selected_topics %}
+			</span>
+			
+			<span id="topic_search_display">
 				<div class="col">
-					<b>Topics:</b> {% for topic in selected_topics %}
-						<div class="label label--tag">{{topic.display_name}}</div>
-					{% endfor %}
+					<b>Topics:</b> <span id="topic_list"></span> <!-- JS will populate this with the current topic list when applicable -->
 				</div>
-				{% endif %}
-				
-			</div>
-		</span>
-	{% else %}
+			</span>
+			
+		</div>
+		<div class="row">
+			<ul class="feed" id="search_results_feed">
+				<!-- Javascript will place results here if there are results to be had. -->
+			</ul>
+		</div>
+	</span>
+	<!-- We'll hide this section if any filters are being used. -->
+	<span class="news_archive" id="news_archive">
 		<div class="row">
 			<h2>News Archive</h2>
 		</div>
-	{% endif %}
-	<div class="row">
-		{% include 'news/includes/news_feed.html' with feed=news_archive feed_id="archive" format="detailed" %}
-	</div>
+		<div class="row">
+			<!-- If we don't have any filters selected, let Django render the archive normally -->
+			{% include 'news/includes/news_feed.html' with feed=news_archive feed_id="archive" format="detailed" %}
+		</div>
+	</span>
 {% endblock %}

--- a/templates/wavepool/base.html
+++ b/templates/wavepool/base.html
@@ -5,6 +5,7 @@
   		<link href="{% static 'css/base.css' %}" rel="stylesheet">
   		<title>Wavepool | Industry Dive</title>
   		<link rel="shortcut icon" type="/image/png" href="{% static 'favicon.ico' %}"/>
+  		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   		{% block extra_style %}{% endblock %}
   </head>
 	<body>


### PR DESCRIPTION
To test:
- Go to archive page
- Select topics and/or enter a search term in the text field (ctrl/command-click will select/deselect multiple in the select field)
- The usual archive view should be replaced by live results right away
- Note the debouncing on the text search - it should not fire off a request for each keypress if they happen quickly
- The 'clear' button will return to the default archive feed behavior and clear any filters.